### PR TITLE
fix: ensure the correct node_modules path is returned when not packaged with asar

### DIFF
--- a/src/bracket-pair-colorizer-2 src/textMateLoader.ts
+++ b/src/bracket-pair-colorizer-2 src/textMateLoader.ts
@@ -116,7 +116,9 @@ export class TextMateLoader {
   }
 
   private getNodeModulePath(moduleName: string) {
-    return path.join(vscode.env.appRoot, "node_modules.asar", moduleName);
+    return fs.existsSync(path.join(vscode.env.appRoot, "node_modules.asar"))
+      ? path.join(vscode.env.appRoot, "node_modules.asar", moduleName)
+      : path.join(vscode.env.appRoot, "node_modules", moduleName);
   }
 
   private getNodeModule(moduleName: string) {


### PR DESCRIPTION
### In this PR

Adds a check to see if VS Code's `node_modules` folder is packaged with `asar` before returning the path to the module. Fixes #17.

### How it was tested

Manually tested by rebuilding with `vcse package` then verifying the updated extension loads without errors in a Dev Container and a local instance of VS Code.

### Other

I haven't included the rebuilt `.vsix`, in case any other changes are being bundled into the next release.