### PR TITLE
Fix extension in remote workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,5 +132,6 @@
     "@typescript-eslint/typescript-estree": "^5.49.0",
     "json5": "^2.2.3",
     "vscode-languageserver-protocol": "^3.17.2"
-  }
+  },
+  "extensionKind": ["ui"]
 }


### PR DESCRIPTION
Closes #54. 

I haven't tested this extensively, however this seems to force the extension to run on the local machine. It works the same as the suggested workaround, but now without the need for each user to set this up themselves..