### PR TITLE
Fixed crashing on new versions of VS Code

### DIFF
--- a/src/bracket-pair-colorizer-2 src/textMateLoader.ts
+++ b/src/bracket-pair-colorizer-2 src/textMateLoader.ts
@@ -116,9 +116,7 @@ export class TextMateLoader {
   }
 
   private getNodeModulePath(moduleName: string) {
-    return fs.existsSync(path.join(vscode.env.appRoot, "node_modules.asar"))
-      ? path.join(vscode.env.appRoot, "node_modules.asar", moduleName)
-      : path.join(vscode.env.appRoot, "node_modules", moduleName);
+    return path.join(vscode.env.appRoot, "node_modules", moduleName);
   }
 
   private getNodeModule(moduleName: string) {

--- a/src/decorators/zenFoldingDecorator.ts
+++ b/src/decorators/zenFoldingDecorator.ts
@@ -38,7 +38,7 @@ export default class ZenFoldingDecorator extends BetterFoldingDecorator {
     const lastVisibleLine = editor.visibleRanges[editor.visibleRanges.length - 1].end.line;
     const cachedFoldedLines = FoldedLinesManager.getFoldedLines(editor);
 
-    const zenFoldedLines = zenLines.filter((line) => cachedFoldedLines?.includes(line) || line === lastVisibleLine);
+    const zenFoldedLines = zenLines.filter((line) => cachedFoldedLines?.has(line) || line === lastVisibleLine);
     const decorationRanges = zenFoldedLines.map(
       (line) => new Range(line, 0, line, editor.document.lineAt(line).text.length)
     );


### PR DESCRIPTION
closes: #66 and #67 

* fixed using includes on a map
* changed the way joining path to node_modules is handled